### PR TITLE
Cleanup extracted date before parsing like check_timed_logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,13 +36,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "check_timed_logs_fast"
-version = "0.2.0"
+version = "0.3.1"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fancy-regex 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "filetime 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "check_timed_logs_fast"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["cmichi <mich@elmueller.net>"]
 license = "MIT"
 description = "A nagios plugin which monitors log files for the occurrence of regular expressions."
@@ -17,3 +17,5 @@ glob = "0.2.11"
 tempfile = "3.0.5"
 filetime = "0.2.1"
 fancy-regex = "0.1.0"
+regex = "*"
+lazy_static = "1.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,10 +30,13 @@
 //!   }
 //! }
 //! ```
+#[macro_use]
+extern crate lazy_static;
 
 extern crate chrono;
 extern crate glob;
 extern crate memmap;
+extern crate regex;
 extern crate time;
 
 pub use config::*;
@@ -43,6 +46,7 @@ use memmap::Mmap;
 use std::fs::File;
 use std::str;
 use std::time::SystemTime;
+use regex::Regex;
 
 mod config;
 mod utils;
@@ -215,7 +219,11 @@ fn search_line(bytes: &[u8], whitespaces_in_datefields: usize, oldest_ts: u64, c
     }
   };
 
-  let date = utils::parse_date(&extracted_date, &conf.date_pattern);
+  lazy_static! {
+    static ref DATE_CLEAN_REGEX: Regex = Regex::new(r"^(\s+|<|\[)|(\s+|>|\])$").unwrap();
+  }
+  let cleaned_date = DATE_CLEAN_REGEX.replace_all(&extracted_date, "");
+  let date = utils::parse_date(&cleaned_date, &conf.date_pattern);
   match date {
     None => Ok(false),
     Some(date) => {


### PR DESCRIPTION
I can't rust. Sorry if this is ugly, I'll fix any comments.
---
check_timed_logs cleans up the extracted date before trying to parse it [1]. As
both check_timed_logs and check_timed_logs_fast ignore lines which don't
contain a valid date not doing the same here leads to silently broken checks
when migrating checks from check_timed_logs without adapting the time pattern
[2].

Sadly we can't use fancy_regex for the cleanup as it doesn't expose a `replace`
method [3]. Luckily it depends on regex (it falls back to regex for non-fancy
regex's) and we don't bloat our binary by just explicitly using regex for our
replacing needs.

[1]
https://exchange.nagios.org/directory/Plugins/Log-Files/check_timed_logs
```
$dateString =~ s/^\s+|\s+$//g ; # remove both leading and tailing whitespace - perl 6 will have a trim() function, until then - regex !
$dateString =~ s/<|>|\]|\[//g ; # remove brackets
```

[2]
Example:
- nginx with the default combined log format
- `-timepattern '%d/%b/%Y:%H:%M:%S' -timeposition 3`
- extracted times look like `[01/Sep/2020:00:00:00`

- check_timed_logs trims the leading `[` and exits with critical
- check_timed_logs_fast doesn't trim the leading `[`, fails to parse the
  date (because the timepattern doesn't contain a leading `[`) and exits with
  OK

[3] https://github.com/fancy-regex/fancy-regex/issues/49